### PR TITLE
Updated esp-idf to v3.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN git clone https://github.com/google/googletest.git /googletest \
 RUN git clone https://github.com/igrr/mkspiffs.git \
     && cd mkspiffs \
 	&& git submodule update --init \
-	&& make dist BUILD_CONFIG_NAME="-esp-idf" CPPFLAGS="-DSPIFFS_OBJ_META_LEN=4" \
+	&& make dist BUILD_CONFIG_NAME="-esp-idf" CPPFLAGS="-DSPIFFS_OBJ_META_LEN=4 -DSPIFFS_OBJ_NAME_LEN=64" \
 	&& cp mkspiffs-0.2.3-6-g983970e-esp-idf-linux64/mkspiffs /usr/bin \
 	&& cd / && rm -rf mkspiffs

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # docker-esp-idf
-This image builds off of the espressif/idf:v3.3.1 image and adds the Google Test
-dependency as well for testing.
+This repository represents the needs for development with esp-idf.
+# Versioning
+There will be times when the docker image will need to be updated. In order to preserve the esp-idf version in combination
+with our own changes, the standard docker image tag will be wsbu/esp-idf:v[esp-idf-version]-[wsbu-version].


### PR DESCRIPTION
These changes are to use the esp-idf v3.1.2 base docker image.