### PR TITLE
Actually bumping to v3.3.2 for esp-idf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM espressif/idf:v3.3.1
+FROM espressif/idf:v3.3.2
 
 RUN apt-get update
+
+# Add CMake
+RUN apt-get -y install cmake
 
 # Add Googletest
 RUN git clone https://github.com/google/googletest.git /googletest \


### PR DESCRIPTION
I didn't bump the esp-idf version last time. This corrects that. This new version doesn't come with cmake preinstalled like the last one for some reason, so an installation of cmake has been added as well.