### PR TITLE
Apply Red Lion patches to the v3.3.2 release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,13 @@ RUN npm install -g @angular/cli
 
 # Apply patch for nvs_partition_gen.py
 COPY nvs_partition_gen.py /opt/esp/idf/components/nvs_flash/nvs_partition_generator
+
+# Apply Red Lion patches to v3.3.2.
+
+#
+# Copy patches into area where docker image can get to them.
+#
+COPY patches/* /tmp/
+
+RUN cd /opt/esp/idf &&  \
+    git apply --verbose /tmp/*.patch

--- a/patches/0001-MB_ASCII-Fix-assert-in-xMBASCIITimerTISExpired.patch
+++ b/patches/0001-MB_ASCII-Fix-assert-in-xMBASCIITimerTISExpired.patch
@@ -1,0 +1,29 @@
+From be4596836e5b75c9c74e1f5db202535eb33bc6c2 Mon Sep 17 00:00:00 2001
+From: "Kenneth G. Watson" <Ken.Watson@redlion.net>
+Date: Mon, 22 Jun 2020 10:35:02 -0400
+Subject: [PATCH 1/2] MB_ASCII: Fix assert in xMBASCIITimerTISExpired().
+
+Added STATE_RX_IDLE to the list of valid states. Without it, an assertion
+is generated when MB_ASCII timer expires.
+---
+ components/freemodbus/modbus/ascii/mbascii.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/components/freemodbus/modbus/ascii/mbascii.c b/components/freemodbus/modbus/ascii/mbascii.c
+index c513457ea..104c171d5 100644
+--- a/components/freemodbus/modbus/ascii/mbascii.c
++++ b/components/freemodbus/modbus/ascii/mbascii.c
+@@ -421,7 +421,9 @@ xMBASCIITimerT1SExpired( void )
+         break;
+ 
+     default:
+-        assert( ( eRcvState == STATE_RX_RCV ) || ( eRcvState == STATE_RX_WAIT_EOF ) );
++        assert( ( eRcvState == STATE_RX_IDLE ) ||
++                ( eRcvState == STATE_RX_RCV ) ||
++                ( eRcvState == STATE_RX_WAIT_EOF ) );
+         break;
+     }
+     vMBPortTimersDisable(  );
+-- 
+2.25.1
+

--- a/patches/0002-MB_ASCII-Enable-inclusion-of-the-MB-ASCII-code-in-Fr.patch
+++ b/patches/0002-MB_ASCII-Enable-inclusion-of-the-MB-ASCII-code-in-Fr.patch
@@ -1,0 +1,26 @@
+From d41c48da4a0441ec309d1ec31d55d5bbeaca1973 Mon Sep 17 00:00:00 2001
+From: "Kenneth G. Watson" <Ken.Watson@redlion.net>
+Date: Mon, 22 Jun 2020 10:44:01 -0400
+Subject: [PATCH 2/2] MB_ASCII: Enable inclusion of the MB ASCII code in
+ FreeModbus component.
+
+---
+ components/freemodbus/modbus/include/mbconfig.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/freemodbus/modbus/include/mbconfig.h b/components/freemodbus/modbus/include/mbconfig.h
+index 54194de26..d5f5eef92 100644
+--- a/components/freemodbus/modbus/include/mbconfig.h
++++ b/components/freemodbus/modbus/include/mbconfig.h
+@@ -47,7 +47,7 @@ PR_BEGIN_EXTERN_C
+  *  @{
+  */
+ /*! \brief If Modbus ASCII support is enabled. */
+-#define MB_ASCII_ENABLED                        (  0 )
++#define MB_ASCII_ENABLED                        (  1 )
+ 
+ /*! \brief If Modbus RTU support is enabled. */
+ #define MB_RTU_ENABLED                          (  1 )
+-- 
+2.25.1
+


### PR DESCRIPTION
This applies two patches to:
 * Fix MB_ASCII timer timeout error - missing STATE_RX_IDLE as valid state in xMBASCIITimerT1SExpired()
 * Enable MB_ASCII code - currently was not compiled into compenent code.